### PR TITLE
Add multi-tier reporting across separate dashboard pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ The showback configuration is entirely within the terraform.tfvars file. Copy [t
   - billable ingest per GB (`gb_ingest_usd`)
 - `showback_ignore.groups`: whether specific user group membership should be ignored. Some customers grant read-only access to all accounts, which breaks the script’s showback user apportioning
 - `showback_ignore.newrelic`: whether New Relic employees should be ignored in the showback charge, set to `true`, but can be changed
-- `showback_config`: for each department, the `department_name`, an optional `tier` number (for grouping departments into higher level reporting units), and accounts either as a list (`accounts_in`) or as a list of one or more regular expressions (`accounts_regex`)
+- `showback_config`: for each department, the `department_name`, an optional `tier` value (for grouping departments into higher level reporting units), and accounts either as a list (`accounts_in`) or as a list of one or more regular expressions (`accounts_regex`)
 
+The expectation with the tier value is that all accounts are separately mapped to a reporting unit. Any additional tiers will be displayed on a separate page on the dashboard with the page title set to the tier name, e.g. 'Reporting Unit'.
 
 ## Initialization
 Use the `runtf.sh` helper script wherever you would normally run `terraform`. It simply wraps the terraform with some environment variables that make it easier to switch between projects. (You don't have to do it this way, you could just set the env vars and run terraform normally.)

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -1,19 +1,19 @@
 # Use a templatefile. For dashboards with many replacement values this is cleaner than using replace().
 locals {
-  total_consumption_cost_by_department_this_month = "FROM Metric, NrConsumption SELECT (max(`showback.department.coreuser.count`) * ${var.showback_price.core_user_usd}) + (max(`showback.department.fulluser.count`) * ${var.showback_price.full_user_usd}) + (sum(GigabytesIngested) * ${var.showback_price.gb_ingest_usd}) AS 'Total Cost (USD)' SINCE this month FACET CASES(WHERE (department = 'Unassigned' AND (tier = {{tier_var}} OR tier IS NULL)) AS 'Unassigned', %{ for index_department, department in var.showback_config ~}%{ if index_department != 0 ~}, %{ endif }WHERE (department = '${department.department_name}' AND (tier = {{tier_var}} OR tier IS NULL)) OR consumingAccountName IN (%{ for index_accounts_in, account in department.accounts_in }%{ if index_accounts_in != 0 ~}, %{ endif }'${account}'%{ endfor ~})%{ for regex in department.accounts_regex } OR consumingAccountName RLIKE r'${regex}'%{ endfor } AS '${department.department_name}'%{ endfor ~}) AS 'department'"
-
-  consumption_cost_by_department_this_month = "FROM Metric, NrConsumption SELECT max(`showback.department.coreuser.count`) * ${var.showback_price.core_user_usd} + max(`showback.department.fulluser.count`) * ${var.showback_price.full_user_usd} + sum(GigabytesIngested) * ${var.showback_price.gb_ingest_usd} AS 'Total Cost (USD)', max(`showback.department.fulluser.count`) AS 'Full User Count', max(`showback.department.fulluser.count`) * ${var.showback_price.full_user_usd} as 'Full User Cost (USD)', max(`showback.department.coreuser.count`) AS 'Core User Count', max(`showback.department.coreuser.count`) * ${var.showback_price.core_user_usd} as 'Core User Cost (USD)', sum(GigabytesIngested) AS ingestGigabytes, sum(GigabytesIngested) * ${var.showback_price.gb_ingest_usd} AS 'Ingest Cost (USD)' SINCE this month FACET CASES(WHERE (department = 'Unassigned' AND (tier = {{tier_var}} OR tier IS NULL)) AS 'Unassigned', %{ for index_department, department in var.showback_config ~}%{ if index_department != 0 ~}, %{ endif }WHERE (department = '${department.department_name}' AND (tier = {{tier_var}} OR tier IS NULL)) OR consumingAccountName IN (%{ for index_accounts_in, account in department.accounts_in }%{ if index_accounts_in != 0 ~}, %{ endif }'${account}'%{ endfor ~})%{ for regex in department.accounts_regex } OR consumingAccountName RLIKE r'${regex}'%{ endfor } as '${department.department_name}'%{ endfor ~}) AS 'department'"
+  unique_tiers = distinct([
+    for department in var.showback_config : department.tier
+  ])
 
   templatefile_render = templatefile(
    "${path.module}/dashboards/dashboard.json.tftpl",
     {
-     tf_dashboard_name = var.dashboard_name
-     tf_account_id = var.showback_insert_account_id
-     tf_total_consumption_cost_by_department_this_month = local.total_consumption_cost_by_department_this_month
-     tf_consumption_cost_by_department_this_month = local.consumption_cost_by_department_this_month
-     tf_core_user_usd = var.showback_price.core_user_usd
-     tf_full_user_usd = var.showback_price.full_user_usd
-     tf_gb_ingest_usd = var.showback_price.gb_ingest_usd
+      tf_showback_config = var.showback_config
+      tf_dashboard_name = var.dashboard_name
+      tf_account_id = var.showback_insert_account_id
+      tf_core_user_usd = var.showback_price.core_user_usd
+      tf_full_user_usd = var.showback_price.full_user_usd
+      tf_gb_ingest_usd = var.showback_price.gb_ingest_usd
+      tf_unique_tiers = local.unique_tiers
     }
   )
 }
@@ -35,10 +35,8 @@ output "templatefile_dashboard" {
   value=newrelic_one_dashboard_json.templatefile_dashboard.permalink 
 }
 
-output "total_consumption_cost_by_department_this_month" {
-  value = local.total_consumption_cost_by_department_this_month
-}
-
-output "consumption_cost_by_department_this_month" {
-  value = local.consumption_cost_by_department_this_month
+output "unique_tiers" {
+  value = distinct([
+    for department in var.showback_config : department.tier
+  ])
 }

--- a/dashboards/dashboard.json.tftpl
+++ b/dashboards/dashboard.json.tftpl
@@ -3,6 +3,232 @@
   "description": null,
   "permissions": "PUBLIC_READ_WRITE",
   "pages": [
+    %{~ for index, tier in tf_unique_tiers ~}
+    %{~ if tier != null ~}
+    {
+      "name": "${tier}",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Consumption Cost (this month)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": ${tf_account_id},
+                "query": "FROM Metric, NrConsumption SELECT (max(`showback.department.coreuser.count`) * ${tf_core_user_usd}) + (max(`showback.department.fulluser.count`) * ${tf_full_user_usd}) + (sum(GigabytesIngested) * ${tf_gb_ingest_usd}) AS 'Total Cost (USD)' SINCE this month FACET CASES(WHERE (department = 'Unassigned' AND (tier = '${tier}')) AS 'Unassigned', %{ for index_department, department in tf_showback_config ~}%{ if index_department != 0 ~}, %{ endif }WHERE (department = '${department.department_name}' AND (tier = '${tier}')) OR consumingAccountName IN (%{ for index_accounts_in, account in department.accounts_in }%{ if index_accounts_in != 0 ~}, %{ endif }'${account}'%{ endfor ~})%{ for regex in department.accounts_regex } OR consumingAccountName RLIKE r'${regex}'%{ endfor } AS '${department.department_name}'%{ endfor ~}) AS 'department'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Consumption Cost (this month)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 8,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": ${tf_account_id},
+                "query": "FROM Metric, NrConsumption SELECT max(`showback.department.coreuser.count`) * ${tf_core_user_usd} + max(`showback.department.fulluser.count`) * ${tf_full_user_usd} + sum(GigabytesIngested) * ${tf_gb_ingest_usd} AS 'Total Cost (USD)', max(`showback.department.fulluser.count`) AS 'Full User Count', max(`showback.department.fulluser.count`) * ${tf_full_user_usd} as 'Full User Cost (USD)', max(`showback.department.coreuser.count`) AS 'Core User Count', max(`showback.department.coreuser.count`) * ${tf_core_user_usd} as 'Core User Cost (USD)', sum(GigabytesIngested) AS ingestGigabytes, sum(GigabytesIngested) * ${tf_gb_ingest_usd} AS 'Ingest Cost (USD)' SINCE this month FACET CASES(WHERE (department = 'Unassigned' AND (tier = '${tier}')) AS 'Unassigned', %{ for index_department, department in tf_showback_config ~}%{ if index_department != 0 ~}, %{ endif }WHERE (department = '${department.department_name}' AND (tier = '${tier}')) OR consumingAccountName IN (%{ for index_accounts_in, account in department.accounts_in }%{ if index_accounts_in != 0 ~}, %{ endif }'${account}'%{ endfor ~})%{ for regex in department.accounts_regex } OR consumingAccountName RLIKE r'${regex}'%{ endfor } as '${department.department_name}'%{ endfor ~}) AS 'department'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Full Users",
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId":  ${tf_account_id},
+                "query": "SELECT latest(`showback.department.fulluser.count`) AS 'Full User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = '${tier}' LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Core Users",
+          "layout": {
+            "column": 4,
+            "row": 5,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": ${tf_account_id},
+                "query": "SELECT latest(`showback.department.coreuser.count`) AS 'Core User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = '${tier}' LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Basic Users",
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": ${tf_account_id},
+                "query": "SELECT latest(`showback.department.basicuser.count`) AS 'Basic User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = '${tier}' LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Total Users",
+          "layout": {
+            "column": 10,
+            "row": 5,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": ${tf_account_id},
+                "query": "SELECT latest(`showback.department.totaluser.count`) AS 'Total User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = '${tier}' LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Total Consumption by Month",
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "width": 12,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Ingest Cost",
+                "precision": 2,
+                "type": "decimal"
+              },
+              {
+                "name": "Total Cost",
+                "precision": 2,
+                "type": "decimal"
+              }
+            ],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": ${tf_account_id},
+                "query": "FROM NrMTDConsumption\nSELECT\n  filter(latest(billableConsumption), WHERE metric = 'FullUsers' OR metric = 'FullPlatformUsers') * ${tf_full_user_usd} + filter(latest(billableConsumption) OR 0, WHERE metric = 'CoreUsers') * ${tf_core_user_usd} + filter(latest(GigabytesIngestedBillable) * ${tf_gb_ingest_usd}, WHERE productLine = 'DataPlatform') AS 'Total Cost (USD)',\n  filter(latest(billableConsumption), WHERE metric = 'FullUsers' OR metric = 'FullPlatformUsers') AS 'FSO User Count',\n  filter(latest(billableConsumption), WHERE metric = 'FullUsers' OR metric = 'FullPlatformUsers') * ${tf_full_user_usd} as 'FSO User Cost (USD)',\n  filter(latest(billableConsumption) OR 0, WHERE metric = 'CoreUsers') AS 'Core User Count',\n  filter(latest(billableConsumption) OR 0, WHERE metric = 'CoreUsers') * ${tf_core_user_usd} AS 'Core User Cost (USD)',\n filter(latest(GigabytesIngestedBillable), WHERE productLine = 'DataPlatform') AS 'Ingested GB',\n  filter(latest(GigabytesIngestedBillable) * ${tf_gb_ingest_usd}, WHERE productLine = 'DataPlatform') AS 'Ingest Cost (USD)'\nSINCE 12 months ago facet monthOf(timestamp) order by timestamp"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        }
+      ]
+    },
+    %{ endif ~}
+    %{ endfor ~}
     {
       "name": "Department Showback",
       "description": null,
@@ -29,7 +255,7 @@
             "nrqlQueries": [
               {
                 "accountId": ${tf_account_id},
-                "query": "${tf_total_consumption_cost_by_department_this_month}"
+                "query": "FROM Metric, NrConsumption SELECT (max(`showback.department.coreuser.count`) * ${tf_core_user_usd}) + (max(`showback.department.fulluser.count`) * ${tf_full_user_usd}) + (sum(GigabytesIngested) * ${tf_gb_ingest_usd}) AS 'Total Cost (USD)' SINCE this month FACET CASES(WHERE (department = 'Unassigned' AND (tier IS NULL)) AS 'Unassigned', %{ for index_department, department in tf_showback_config ~}%{ if index_department != 0 ~}, %{ endif }WHERE (department = '${department.department_name}' AND (tier IS NULL)) OR consumingAccountName IN (%{ for index_accounts_in, account in department.accounts_in }%{ if index_accounts_in != 0 ~}, %{ endif }'${account}'%{ endfor ~})%{ for regex in department.accounts_regex } OR consumingAccountName RLIKE r'${regex}'%{ endfor } AS '${department.department_name}'%{ endfor ~}) AS 'department'"
               }
             ],
             "platformOptions": {
@@ -56,7 +282,7 @@
             "nrqlQueries": [
               {
                 "accountId": ${tf_account_id},
-                "query": "${tf_consumption_cost_by_department_this_month}"
+                "query": "FROM Metric, NrConsumption SELECT max(`showback.department.coreuser.count`) * ${tf_core_user_usd} + max(`showback.department.fulluser.count`) * ${tf_full_user_usd} + sum(GigabytesIngested) * ${tf_gb_ingest_usd} AS 'Total Cost (USD)', max(`showback.department.fulluser.count`) AS 'Full User Count', max(`showback.department.fulluser.count`) * ${tf_full_user_usd} as 'Full User Cost (USD)', max(`showback.department.coreuser.count`) AS 'Core User Count', max(`showback.department.coreuser.count`) * ${tf_core_user_usd} as 'Core User Cost (USD)', sum(GigabytesIngested) AS ingestGigabytes, sum(GigabytesIngested) * ${tf_gb_ingest_usd} AS 'Ingest Cost (USD)' SINCE this month FACET CASES(WHERE (department = 'Unassigned' AND (tier IS NULL)) AS 'Unassigned', %{ for index_department, department in tf_showback_config ~}%{ if index_department != 0 ~}, %{ endif }WHERE (department = '${department.department_name}' AND (tier IS NULL)) OR consumingAccountName IN (%{ for index_accounts_in, account in department.accounts_in }%{ if index_accounts_in != 0 ~}, %{ endif }'${account}'%{ endfor ~})%{ for regex in department.accounts_regex } OR consumingAccountName RLIKE r'${regex}'%{ endfor } as '${department.department_name}'%{ endfor ~}) AS 'department'"
               }
             ],
             "platformOptions": {
@@ -86,7 +312,7 @@
             "nrqlQueries": [
               {
                 "accountId":  ${tf_account_id},
-                "query": "SELECT latest(`showback.department.fulluser.count`) AS 'Full User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = {{tier_var}} OR tier IS NULL LIMIT MAX"
+                "query": "SELECT latest(`showback.department.fulluser.count`) AS 'Full User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier IS NULL LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -116,7 +342,7 @@
             "nrqlQueries": [
               {
                 "accountId": ${tf_account_id},
-                "query": "SELECT latest(`showback.department.coreuser.count`) AS 'Core User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = {{tier_var}} OR tier IS NULL LIMIT MAX"
+                "query": "SELECT latest(`showback.department.coreuser.count`) AS 'Core User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier IS NULL LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -146,7 +372,7 @@
             "nrqlQueries": [
               {
                 "accountId": ${tf_account_id},
-                "query": "SELECT latest(`showback.department.basicuser.count`) AS 'Basic User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = {{tier_var}} OR tier IS NULL LIMIT MAX"
+                "query": "SELECT latest(`showback.department.basicuser.count`) AS 'Basic User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier IS NULL LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -176,7 +402,7 @@
             "nrqlQueries": [
               {
                 "accountId": ${tf_account_id},
-                "query": "SELECT latest(`showback.department.totaluser.count`) AS 'Total User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier = {{tier_var}} OR tier IS NULL LIMIT MAX"
+                "query": "SELECT latest(`showback.department.totaluser.count`) AS 'Total User Count' FROM Metric SINCE 1 DAY AGO facet department WHERE tier IS NULL LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -453,27 +679,5 @@
       ]
     }
   ],
-  "variables": [
-    {
-      "name": "tier_var",
-      "items": null,
-      "defaultValues": [
-        {
-          "value": {
-            "string": "1"
-          }
-        }
-      ],
-      "nrqlQuery": {
-        "accountIds": [
-          2010237
-        ],
-        "query": "SELECT uniques(tier) FROM Metric WHERE metricName = 'showback.department.fulluser.count' SINCE 24 hours ago"
-      },
-      "title": "Tier",
-      "type": "NRQL",
-      "isMultiSelection": false,
-      "replacementStrategy": "NUMBER"
-    }
-  ]
+  "variables": []
 }

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,4 +1,8 @@
 locals {
+  dept_to_tier_map = jsonencode([
+    for department in var.showback_config : [ department.department_name, department.tier ]
+  ])
+
   templatefile_render = templatefile(
    "${path.module}/showback_script.tftpl",
     {
@@ -7,6 +11,7 @@ locals {
       tf_showback_ignore_groups = var.showback_ignore.groups
       tf_showback_ignore_newrelic_users = var.showback_ignore.newrelic_users
       tf_showback_config = var.showback_config
+      tf_dept_to_tier_map = local.dept_to_tier_map
     }
   )
 }
@@ -45,4 +50,8 @@ output "showback_ignore_newrelic_users" {
 
 output "showback_ignore_groups" {
   value = var.showback_ignore.groups
+}
+
+output "dept_to_tier_map" {
+  value = local.dept_to_tier_map
 }

--- a/modules/monitor/showback_script.tftpl
+++ b/modules/monitor/showback_script.tftpl
@@ -50,8 +50,6 @@ const CHUNK_SIZE = 100;
 const GQL_API_CHUNK_SIZE = 25;
 const MAX_RETRIES = 3;
 
-const DEFAULT_DEPT_TIER = 1;
-
 
 /**
  * Process showback (https://en.wikipedia.org/wiki/IT_chargeback_and_showback) for an organization, as associated with the supplied user api key. 
@@ -120,11 +118,11 @@ async function processShowback() {
   // Get department to tier map
   let departmentToTierMap = getDepartmentToTierMap();
 
-  // Get the number of tiers
-  let numTiers = getNumTiers(departmentToTierMap);
+  // Get the tier set
+  let tierSet = getTierSet(departmentToTierMap);
 
   // Build a map of departments to their user type counts, and also return an updated email to user map with the departments added
-  let { tierToDepartmentToUserTypeCountsMapMap, emailToDepartmentSetMap } = buildDepartmentToUserTypeCountsMap(consolidatedEmailToAccountSetMap, consolidatedEmailToUserAndGroupsMap, numTiers, accountIdToAccountMap);
+  let { tierToDepartmentToUserTypeCountsMapMap, emailToDepartmentSetMap } = buildDepartmentToUserTypeCountsMap(consolidatedEmailToAccountSetMap, consolidatedEmailToUserAndGroupsMap, tierSet, accountIdToAccountMap);
 
   // Build a map of accounts, by id, to their users
   let accountIdToUsersMap = buildAccountToUsersMap(enrichedEmailToUserAndGroupsMap, groupIdToRolesMap);
@@ -197,25 +195,21 @@ function getDepartmentMapping(account) {
  * @returns the department to tier map.
  */
 function getDepartmentToTierMap() {
-  return new Map([
-    %{~ for index_department, department in tf_showback_config ~}
-    [ "${department.department_name}", ${department.tier} ]%{~ if (index_department + 1) < length(tf_showback_config) },%{~ endif }
-    %{~ endfor ~}
-  ]);
+  return new Map(${tf_dept_to_tier_map});
 }
 
 
 /**
- * Gets the number of tiers.
+ * Gets the tier set.
  * @param {*} deptToTierMap 
- * @returns the number of tiers.
+ * @returns the tier set.
  */
-function getNumTiers(deptToTierMap) {
+function getTierSet(deptToTierMap) {
   let tierSet = new Set();
   for (const [dept, tier] of deptToTierMap) {
     tierSet.add(tier);
   }
-  return tierSet.size;
+  return tierSet;
 }
 
 
@@ -717,11 +711,11 @@ function buildEmailToAccountsMap(emailToUserAndGroupsMap, groupIdToRolesMap, acc
  * Build a map of departments to their user type counts.
  * @param {*} consolidatedEmailToAccountSetMap a (case insensitive) map of users (by email) to their accounts.
  * @param {*} consolidatedEmailToUserAndGroupsMap a (case insensitive) map of users (by email) to their user details and groups.
- * @param {*} numTiers the number of tiers.
+ * @param {*} tierSet the set of tiers.
  * @param {*} accountIdToAccountMap a map of account ids to accounts.
  * @returns a map of tiers to a map of departments to their user type counts, and a map of user to consolidated departments.
  */
-function buildDepartmentToUserTypeCountsMap(consolidatedEmailToAccountSetMap, consolidatedEmailToUserAndGroupsMap, numTiers, accountIdToAccountMap) {
+function buildDepartmentToUserTypeCountsMap(consolidatedEmailToAccountSetMap, consolidatedEmailToUserAndGroupsMap, tierSet, accountIdToAccountMap) {
   let tierToDepartmentToUserTypeCountsMapMap = new Map();
   let emailToDepartmentSetMap = new Map();
   let ignoreNewRelicUsers = ${tf_showback_ignore_newrelic_users};
@@ -746,7 +740,7 @@ function buildDepartmentToUserTypeCountsMap(consolidatedEmailToAccountSetMap, co
     // Handle users with no accounts
     if (accountSet.size == 0) {
       console.error("buildDepartmentToUserTypeCountsMap: User has no accounts:", email);
-      for (let tier = 1; tier <= numTiers; tier++) {
+      for (const tier of tierSet) {
         tierToDeptSetMap.set(tier, new Set([DEPARTMENT_UNASSIGNED]));
       }
     }
@@ -852,20 +846,24 @@ function postDepartmentShowback(tierToDepartmentToUserTypeCountsMapMap, departme
         }
       }
       // Build department metrics
-      let basicUserDeptMetric = getDimensionalMetricObject("showback.department.basicuser.count", "gauge", userTypeCountsObject.basic, timestamp, { "department": department, "tier": tier });
+      let attributes = { "department": department };
+      if (tier) {
+        attributes.tier = tier;
+      }
+      let basicUserDeptMetric = getDimensionalMetricObject("showback.department.basicuser.count", "gauge", userTypeCountsObject.basic, timestamp, attributes);
       metrics.push(basicUserDeptMetric);
       aggregateUserCountObject.basic += userTypeCountsObject.basic;
 
-      let coreUserDeptMetric = getDimensionalMetricObject("showback.department.coreuser.count", "gauge", userTypeCountsObject.core, timestamp, { "department": department, "tier": tier });
+      let coreUserDeptMetric = getDimensionalMetricObject("showback.department.coreuser.count", "gauge", userTypeCountsObject.core, timestamp, attributes);
       metrics.push(coreUserDeptMetric);
       aggregateUserCountObject.core += userTypeCountsObject.core;
 
-      let fullUserDeptMetric = getDimensionalMetricObject("showback.department.fulluser.count", "gauge", userTypeCountsObject.full_platform, timestamp, { "department": department, "tier": tier });
+      let fullUserDeptMetric = getDimensionalMetricObject("showback.department.fulluser.count", "gauge", userTypeCountsObject.full_platform, timestamp, attributes);
       metrics.push(fullUserDeptMetric);
       aggregateUserCountObject.full += userTypeCountsObject.full_platform;
 
       let totalUserDeptCount = userTypeCountsObject.basic + userTypeCountsObject.core + userTypeCountsObject.full_platform;
-      let totalUserDeptMetric = getDimensionalMetricObject("showback.department.totaluser.count", "gauge", totalUserDeptCount, timestamp, { "department": department, "tier": tier });
+      let totalUserDeptMetric = getDimensionalMetricObject("showback.department.totaluser.count", "gauge", totalUserDeptCount, timestamp, attributes);
       metrics.push(totalUserDeptMetric);
       aggregateUserCountObject.total += totalUserDeptCount;
       tierToAggregateUserCountObjectMap.set(tier, aggregateUserCountObject);
@@ -874,13 +872,14 @@ function postDepartmentShowback(tierToDepartmentToUserTypeCountsMapMap, departme
 
   // Aggregates metrics
   for (const [tier, aggregateUserCountObject] of tierToAggregateUserCountObjectMap) {
-    let totalBasicUserMetric = getDimensionalMetricObject("showback.organization.basicuser.count", "gauge", aggregateUserCountObject.basic, timestamp, { "tier": tier });
+    let attributes = tier ? { "tier": tier } : null;
+    let totalBasicUserMetric = getDimensionalMetricObject("showback.organization.basicuser.count", "gauge", aggregateUserCountObject.basic, timestamp, attributes);
     metrics.push(totalBasicUserMetric);
-    let totalCoreUserMetric = getDimensionalMetricObject("showback.organization.coreuser.count", "gauge", aggregateUserCountObject.core, timestamp, { "tier": tier });
+    let totalCoreUserMetric = getDimensionalMetricObject("showback.organization.coreuser.count", "gauge", aggregateUserCountObject.core, timestamp, attributes);
     metrics.push(totalCoreUserMetric);
-    let totalFullUserMetric = getDimensionalMetricObject("showback.organization.fulluser.count", "gauge", aggregateUserCountObject.full, timestamp, { "tier": tier });
+    let totalFullUserMetric = getDimensionalMetricObject("showback.organization.fulluser.count", "gauge", aggregateUserCountObject.full, timestamp, attributes);
     metrics.push(totalFullUserMetric);
-    let totalUserMetric = getDimensionalMetricObject("showback.organization.totaluser.count", "gauge", aggregateUserCountObject.total, timestamp, { "tier": tier });
+    let totalUserMetric = getDimensionalMetricObject("showback.organization.totaluser.count", "gauge", aggregateUserCountObject.total, timestamp, attributes);
     metrics.push(totalUserMetric);
   }
 
@@ -898,13 +897,16 @@ function postDepartmentShowback(tierToDepartmentToUserTypeCountsMapMap, departme
  * @returns a dimensional metric object.
  */
 function getDimensionalMetricObject(name, type, value, timestamp, attributes) {
-  return {
+  let dimensionalMetricObject = {
     "name": name,
     "type": type,
     "value": value,
-    "timestamp": timestamp,
-    "attributes": attributes
+    "timestamp": timestamp
   };
+  if (attributes) {
+    dimensionalMetricObject.attributes = attributes;
+  }
+  return dimensionalMetricObject;
 }
 
 
@@ -917,21 +919,25 @@ function getDimensionalMetricObject(name, type, value, timestamp, attributes) {
  */
 function postAccounts(accountToUsersMap, accountIdToAccountMap, timestamp) {
   let accountArray = [];
-  for (const [accountId, users] of accountToUsersMap) {
+  for (const [accountId, account] of accountIdToAccountMap) {
     let basicUserCount = 0, coreUserCount = 0, fullUserCount = 0;
-    for (const user of users) {
-      let userType = user.type;
-      if (userType.displayName === 'Full platform') {
-        fullUserCount++;
-      } else if (userType.displayName === 'Core') {
-        coreUserCount++;
-      } else if (userType.displayName === 'Basic') {
-        basicUserCount++;
-      } else {
-        console.error('postAccounts(): Unknown user type:', userType)
+    let users = accountToUsersMap.get(accountId);
+    if(users) {
+      for (const user of users) {
+        let userType = user.type;
+        if (userType.displayName === 'Full platform') {
+          fullUserCount++;
+        } else if (userType.displayName === 'Core') {
+          coreUserCount++;
+        } else if (userType.displayName === 'Basic') {
+          basicUserCount++;
+        } else {
+          console.error('postAccounts(): Unknown user type:', userType)
+        }
       }
+    } else if (account && !account.isCanceled) {
+      console.warn('postAccounts(): Account ' + account?.name + ' with id ' + accountId + ' has no users');
     }
-    let account = accountIdToAccountMap.get(accountId);
     if (account && !account.isCanceled) {
       accountArray.push(
         {

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -14,7 +14,7 @@ showback_ignore = {
 showback_config = [
   {
     department_name = "Dept 1"  # Both named accounts, and pattern matches
-    tier = 1  // Optional hierarchy of departments, defaults to 1
+    #tier = 'Reporting Unit'  // Optional hierarchy of departments, defaults to null
     accounts_in = [
       "An account that does not match a pattern for this department",
       "Another account not matching a pattern"
@@ -26,7 +26,7 @@ showback_config = [
   },
   {
     department_name = "Dept 2"  # No named accounts, only patterns
-    tier = 2  // Optional hierarchy of departments, defaults to 1
+    #tier = 'Reporting Unit'  // Optional hierarchy of departments, defaults to null
     accounts_in = []
     accounts_regex = [
       "^two..*"
@@ -34,7 +34,7 @@ showback_config = [
   },
   {
     department_name = "Dept 3"  # Only named accounts
-    tier = 1  // Optional hierarchy of departments, defaults to 1
+    #tier = 'Reporting Unit'  // Optional hierarchy of departments, defaults to null
     accounts_in = [
       "Third dept account",
       "Another account from department three"

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "showback_config" {
   description = "Showback config"
   type = list(object({
     department_name = string
-    tier = optional(number, 1)
+    tier = optional(string)
     accounts_in = list(string)
     accounts_regex = list(string)
   }))


### PR DESCRIPTION
The previous number-based tiers have been replaced with string-based tiers, and the default tier is null. New tiers are reporting in a separate dashboard page. 